### PR TITLE
feature: abstract writer into stream/streamless

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,59 @@ npm install @pkgless/diff
 ```
 
 ```ts
-import { diffTokens, tokenize, diffToTextStream } from '@pkgless/diff'
+import {
+  // convert code to tokens
+  tokenize,
+
+  // compare two sets of tokens
+  diffTokens,
+  
+  // gets passed to diffTokens, makes it output Array<DiffOperation>
+  ArrayWriter,
+  
+  // gets passed to diffTokens, makes it output ReadableStream<DiffOperation>
+  ReadableStreamWriter,
+  
+  // convert ReadableStream<DiffOperation> to ReadableStream<string>
+  diffStreamToTextStream,
+  
+  // convert ReadableStream<DiffOperation> to Promise<string>
+  diffStreamToString,
+  
+  // convert Array<DiffOperation> to string
+  diffArrayToString,
+} from '@pkgless/diff'
 ```
 ## Features
 
 - **Formatting Tolerance**: Ignores indents, semicolons, and trailing commas.
 - **Word-Level Diff**: Breaks long strings into words for detailed diffs.
 
+### synchronous
+
+To get a diff synchronously, you can use the ArrayWriter which makes diffTokens return an array of DiffOperations. 
+
+Then print it with `diffArrayToString`.
+
+```ts
+const diff = diffTokens({
+  a: tokenize({
+    content: a,
+    language,
+  }),
+  b: tokenize({
+    content: b,
+    language,
+  }),
+  writer: new ArrayWriter(), // this is the default writer, so feel free to omit
+})
+
+const result = diffArrayToString(diff)
+```
+
 ### streaming text
 
-This API is streaming friendly. If you don't want to stream, you can use `await diffToString(stream)` to buffer the whole diff into a string. 
+This API is streaming friendly. If you don't want to stream the final output, you can use `await diffStreamToString(stream)` to buffer the whole diff into a string. 
 
 ```ts
 app.get('/diff', async (c) => {
@@ -37,9 +80,10 @@ app.get('/diff', async (c) => {
       content: b,
       language,
     }),
+    writer: new ReadableStreamWriter(),
   })
 
-  const stream = diffToTextStream(diffStream)
+  const stream = diffStreamToTextStream(diffStream)
   
   return new Response(stream, {
     headers: {
@@ -64,8 +108,9 @@ app.get('/diff.html', async (c) => {
       content: b,
       language,
     }),
+    writer: new ReadableStreamWriter(),
   })
-  const stream = diffToTextStream(diffStream, {
+  const stream = diffStreamToTextStream(diffStream, {
     insertTagOpen: "<ins>",
     insertTagClose: "</ins>",
     deleteTagOpen: "<del>",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pkgless/diff",
   "type": "module",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "A diff library",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/diff/src/array.ts
+++ b/packages/diff/src/array.ts
@@ -1,0 +1,63 @@
+import { DiffOperation } from "./diff.js"
+import { Writer } from "./writer.js"
+
+export class ArrayWriter extends Writer<Array<DiffOperation>> {
+  private operations: Array<DiffOperation> = []
+
+  write(operation: DiffOperation) {
+    this.operations.push(operation)
+  }
+
+  close() {
+    return this.operations
+  }
+}
+
+export function diffArrayToString(
+  diffArray: Array<DiffOperation>,
+  options: {
+    omit?: Array<"insert" | "delete" | "equal">
+    insertTagOpen?: string
+    insertTagClose?: string
+    deleteTagOpen?: string
+    deleteTagClose?: string
+    equalTagOpen?: string
+    equalTagClose?: string
+} = {}) {
+  let omit = options.omit ?? []
+  let insertTagOpen = options.insertTagOpen ?? "[+ "
+  let insertTagClose = options.insertTagClose ?? " +]"
+  let deleteTagOpen = options.deleteTagOpen ?? "[- "
+  let deleteTagClose = options.deleteTagClose ?? " -]"
+  let equalTagOpen = options.equalTagOpen ?? ""
+  let equalTagClose = options.equalTagClose ?? ""
+
+  let result = ""
+  for (const change of diffArray) {
+    if (change.type === "insert" && !omit.includes("insert")) {
+      result += insertTagOpen
+      for (const token of change.tokens) {
+        result += token.value
+      }
+      result += insertTagClose
+    }
+
+    if (change.type === "delete" && !omit.includes("delete")) {
+      result += deleteTagOpen
+      for (const token of change.tokens) {
+        result += token.value
+      }
+      result += deleteTagClose
+    }
+
+    if (change.type === "equal" && !omit.includes("equal")) {
+      result += equalTagOpen
+      for (const token of change.tokens) {
+        result += token.value
+      }
+      result += equalTagClose
+    }
+  }
+
+  return result
+}

--- a/packages/diff/src/diff.test.ts
+++ b/packages/diff/src/diff.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest"
 import { tokenize } from "./tokenize.js"
 import { diffTokens } from "./diff.js"
-import { diffToString } from "./stream.js"
+import { diffArrayToString } from "./array.js"
+import { diffStreamToString, ReadableStreamWriter } from "./stream.js"
 
 const changeQuotes = {
   a: "import * as React from 'react'",
@@ -43,7 +44,7 @@ describe("Reconstruct with Removals Omitted", () => {
       }),
     })
 
-    const result = await diffToString(diff)
+    const result = diffArrayToString(diff)
     expect(result).toBe(bCode)
   })
 
@@ -62,7 +63,7 @@ describe("Reconstruct with Removals Omitted", () => {
       }),
     })
 
-    const result = await diffToString(diff, { omit: ["delete"] })
+    const result = diffArrayToString(diff, { omit: ["delete"] })
     expect(result).toBe(bCode)
   })
 
@@ -81,7 +82,7 @@ describe("Reconstruct with Removals Omitted", () => {
       }),
     })
 
-    const result = await diffToString(diff, { omit: ["delete"] })
+    const result = diffArrayToString(diff, { omit: ["delete"] })
     expect(result).toBe(bCode)
   })
 
@@ -100,11 +101,11 @@ describe("Reconstruct with Removals Omitted", () => {
       }),
     })
 
-    const result = await diffToString(diff, { omit: ["delete"] })
+    const result = diffArrayToString(diff, { omit: ["delete"] })
     expect(result).toBe(bCode)
   })
 
-  it("with deletions omitted, should return bCode", async () => {
+  it("with deletions omitted, should return bCode in array", async () => {
     const aCode = input.a
     const bCode = input.b
 
@@ -119,7 +120,31 @@ describe("Reconstruct with Removals Omitted", () => {
       }),
     })
 
-    const result = await diffToString(diff, {
+    const result = diffArrayToString(diff, {
+      omit: ["delete"],
+      insertTagOpen: "",
+      insertTagClose: "",
+    })
+    expect(result).toBe(bCode)
+  })
+
+  it("with deletions omitted, should return bCode in stream", async () => {
+    const aCode = input.a
+    const bCode = input.b
+
+    const diff = diffTokens({
+      a: tokenize({
+        content: aCode,
+        language: "typescript",
+      }),
+      b: tokenize({
+        content: bCode,
+        language: "typescript",
+      }),
+      writer: new ReadableStreamWriter(),
+    })
+
+    const result = await diffStreamToString(diff, {
       omit: ["delete"],
       insertTagOpen: "",
       insertTagClose: "",

--- a/packages/diff/src/writer.ts
+++ b/packages/diff/src/writer.ts
@@ -1,0 +1,11 @@
+import { DiffOperation } from "./diff.js"
+
+export class Writer<T> {
+  write(operation: DiffOperation) {
+    throw new Error("Method 'write()' must be implemented.")
+  }
+
+  close(): T {
+    throw new Error("Method 'close()' must be implemented.")
+  }
+}


### PR DESCRIPTION
If it weren't for the ReadableStream, we could run this synchronously client side, even in a React component

This PR abstracts a Writer class that allows choosing between a ReadableStream or an array when creating the diffs. 